### PR TITLE
fix[mapper] - 修复已删除文章对归档统计的影响

### DIFF
--- a/blog-springboot/src/main/resources/mapper/BlogMapper.xml
+++ b/blog-springboot/src/main/resources/mapper/BlogMapper.xml
@@ -146,6 +146,7 @@
 
     <select id="statisticalBlogByMonth" parameterType="Integer" resultType="Map">
         SELECT YEAR(blog_time) year, MONTH(blog_time) month,COUNT(1) count FROM blog
+        WHERE blog_state = 1
         GROUP BY YEAR(blog_time),MONTH(blog_time)
         ORDER by blog_time DESC
         LIMIT 0,#{value}


### PR DESCRIPTION
我在测试的时候发现，发现**已删除博客** 依然对 **归档统计的博客数**有影响

虽然在service层中管理员/用户删除博客后，会删除掉Redis中的Key为`STATISTICAL`的归档信息，但是之后当主页重新加载时，依然会从数据库中查出博客数(包括已删除博客)

归根到底是在SQL查询层面(mapper)需要加入一个对博客状态(blog_state)的筛选